### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/config/fdi2iclass.py
+++ b/config/fdi2iclass.py
@@ -150,7 +150,7 @@ def parse_all_matches(node):
 
         # walk up to a parent match node
         node = node.parentNode
-        if node == None or not is_match_node(node):
+        if node is None or not is_match_node(node):
             break
 
         # leave if there other options at this level


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:xorg-server?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:xorg-server?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
