### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/config/fdi2iclass.py
+++ b/config/fdi2iclass.py
@@ -167,16 +167,16 @@ def print_section(matches, driver, ignore, options):
     '''Print a valid InputClass section to stdout'''
     global num_sections
     print 'Section "InputClass"'
-    print '\tIdentifier "Converted Class %d"' % num_sections
+    print '\tIdentifier "Converted Class {0:d}"'.format(num_sections)
     num_sections += 1
     for m, v in matches:
-        print '\t%s "%s"' % (m, v)
+        print '\t{0!s} "{1!s}"'.format(m, v)
     if driver:
-        print '\tDriver "%s"' % driver
+        print '\tDriver "{0!s}"'.format(driver)
     if ignore:
         print '\tOption "Ignore" "yes"'
     for o, v in options:
-        print '\tOption "%s" "%s"' % (o, v)
+        print '\tOption "{0!s}" "{1!s}"'.format(o, v)
     print 'EndSection'
 
 def parse_fdi(fdi):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:xorg-server?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:xorg-server?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
